### PR TITLE
Update models to use numpy arrays for domain and range

### DIFF
--- a/pybmc/models.py
+++ b/pybmc/models.py
@@ -1,5 +1,24 @@
+import numpy as np
+
 class Model:
-    def __init__(self, name, domain, range):
+    """
+    A class representing a model with a domain (x) and an output (y).
+
+    Attributes:
+        name (str): The name of the model.
+        x (np.ndarray): The domain of the model.
+        y (np.ndarray): The output of the model.
+    """
+
+    def __init__(self, name, x, y):
+        """
+        Initialize the Model object.
+
+        Args:
+            name (str): The name of the model.
+            x (array-like): The domain of the model.
+            y (array-like): The output of the model.
+        """
         self.name = name
-        self.domain = domain
-        self.range = range
+        self.x = np.array(x)
+        self.y = np.array(y)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,18 +1,17 @@
 import unittest
+import numpy as np
 from pybmc.models import Model
 
 
 class TestModel(unittest.TestCase):
     def setUp(self):
-        self.model = Model("test_model")
+        self.model = Model("test_model", np.array([1, 2, 3, 4, 5]), np.array([10, 20, 30, 40, 50]))
 
-    def test_domain(self):
-        self.model.domain = [1, 2, 3, 4, 5]
-        self.assertEqual(self.model.domain, [1, 2, 3, 4, 5])
+    def test_x(self):
+        np.testing.assert_array_equal(self.model.x, np.array([1, 2, 3, 4, 5]))
 
-    def test_range(self):
-        self.model.range = [10, 20, 30, 40, 50]
-        self.assertEqual(self.model.range, [10, 20, 30, 40, 50])
+    def test_y(self):
+        np.testing.assert_array_equal(self.model.y, np.array([10, 20, 30, 40, 50]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Enforce that Model's domain and output are numpy arrays and rename them to x and y.

* Import numpy as np in `pybmc/models.py` and `tests/test_models.py`.
* Update `Model` class in `pybmc/models.py`:
  - Enforce that `x` and `y` are numpy arrays in the `__init__` method.
  - Change the `domain` attribute to `x` and `range` attribute to `y`.
  - Add documentation explaining that `x` and `y` correspond to the domain and range of the models.
* Update `TestModel` class in `tests/test_models.py`:
  - Initialize `x` and `y` as numpy arrays in the `setUp` method.
  - Change the `domain` attribute to `x` and `range` attribute to `y` in the test methods.
  - Use `np.testing.assert_array_equal` to test `x` and `y` attributes.

